### PR TITLE
Fix script loading and add dark mode styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <meta property="og:title" content="Paul Han - Innovative SWE & HWE | Creative Problem Solver">
   <meta property="og:description" content="Discover innovative software & hardware engineering projects. From AI and machine learning to creative problem-solving, explore my journey in technology and engineering.">
   <meta property="og:image" content="https://pauljunsukhan.com/assets/site/social-preview.webp">
-  <meta property="og:image:alt" content="https://pauljunsukhan.com/assets/site/social-preview.png">
+  <meta property="og:image:alt" content="Preview image showing Paul Han's portfolio">
   <meta property="og:image:type" content="image/webp">
   <meta property="og:site_name" content="Paul Han Portfolio">
 
@@ -38,7 +38,7 @@
   <meta name="twitter:title" content="Paul Han - Innovative SWE & HWE | Creative Problem Solver">
   <meta name="twitter:description" content="Discover innovative software & hardware engineering projects. From AI and machine learning to creative problem-solving, explore my journey in technology and engineering.">
   <meta name="twitter:image" content="https://pauljunsukhan.com/assets/site/social-preview.webp">
-  <meta name="twitter:image:alt" content="https://pauljunsukhan.com/assets/site/social-preview.png">
+  <meta name="twitter:image:alt" content="Preview image showing Paul Han's portfolio">
   <meta name="twitter:creator" content="@yourtwitterhandle">
   <meta name="twitter:site" content="@yourtwitterhandle">
 
@@ -191,6 +191,7 @@
   <div class="overlay" aria-hidden="true"></div>
 
   <!-- Scripts -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script type="module" src="scripts/globals.js"></script>
   <script type="module" src="scripts/desktop.js"></script>
   <script type="module" src="scripts/menubar.js"></script>
@@ -250,8 +251,6 @@
     });
   </script>
 
-  <!-- External Library Example (if you use Marked.js for markdown) -->
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 
   <!-- JSON-LD Structured Data (Schema.org) -->
   <script type="application/ld+json">

--- a/styles/global.css
+++ b/styles/global.css
@@ -413,3 +413,21 @@ main.mac-window {
     display: none !important;
   }
 }
+
+/* Dark Mode Theme */
+body.dark-mode {
+  --background-color: #1b1b1b;
+  --text-color: #e0e0e0;
+  --menu-bg: #2b2b2b;
+  --window-bg: #262626;
+  --window-border: #444;
+  --primary-color: #e0e0e0;
+  --secondary-color: #00a3a3;
+  --grid-color: rgba(255, 255, 255, 0.05);
+}
+
+body.dark-mode::after {
+  background: radial-gradient(circle at 50% 50%,
+                              rgba(0, 0, 0, 0.1) 0%,
+                              rgba(0, 0, 0, 0.2) 100%);
+}


### PR DESCRIPTION
## Summary
- load Marked.js before modules
- add alt text for social meta tags
- support a basic dark-mode theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f54c761888321be35c7be93f74b8f