### PR TITLE
Fix preview overlay height

### DIFF
--- a/scripts/projects.js
+++ b/scripts/projects.js
@@ -366,10 +366,10 @@ async function loadProjectPreview(projectId, previewWindow, previewContent) {
     // Create and add iframe
     const iframe = document.createElement('iframe');
     iframe.style.width = '100%';
-    iframe.style.height = '100%';
+    iframe.style.height = 'auto';
     iframe.style.border = 'none';
     
-    // Add load event listener to modify iframe content
+    // Add load event listener to modify iframe content and size
     iframe.onload = () => {
       try {
         const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
@@ -404,6 +404,11 @@ async function loadProjectPreview(projectId, previewWindow, previewContent) {
           }
         `;
         iframeDoc.head.appendChild(style);
+
+        // Adjust iframe height based on content, with 90vh maximum
+        const contentHeight = iframeDoc.documentElement.scrollHeight;
+        const maxHeight = window.innerHeight * 0.9;
+        iframe.style.height = `${Math.min(contentHeight, maxHeight)}px`;
       } catch (err) {
         console.error('Error modifying iframe content:', err);
       }

--- a/styles/projects.css
+++ b/styles/projects.css
@@ -182,7 +182,8 @@ main.mac-window.project-window:hover {
     display: none;
     width: calc(100% - var(--window-margin) * 2);
     max-width: var(--max-width);
-    height: 90vh;
+    max-height: 90vh;
+    height: auto;
 }
 .project-preview.active {
     display: block;
@@ -213,18 +214,20 @@ main.mac-window.project-window:hover {
 }
 .project-preview .preview-content {
     background: var(--window-bg);
-    height: 100%;
+    max-height: 100%;
+    height: auto;
     border: 1px solid var(--window-border);
     border-radius: 0 6px 2px 2px;
     box-shadow: 4px 4px 0 rgba(0,0,0,0.2);
     position: relative;
     z-index: 2000;
-    overflow: hidden;
+    overflow: auto;
 }
 .project-preview .preview-content main.mac-window {
     margin: calc(var(--font-size-base) * 1.4);
     width: calc(100% - calc(var(--font-size-base) * 2.8));
-    height: calc(100% - calc(var(--font-size-base) * 3.15));
+    height: auto;
+    max-height: calc(100% - calc(var(--font-size-base) * 3.15));
     border: 1px solid var(--window-border);
     border-radius: 6px 6px 2px 2px;
     overflow: auto;


### PR DESCRIPTION
## Summary
- allow preview overlay to shrink by using `max-height`
- size iframe to its content and cap at 90vh

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f55ab92ec832195bc312063bc4407