### PR TITLE
Fix mobile menu display

### DIFF
--- a/styles/desktop.css
+++ b/styles/desktop.css
@@ -186,10 +186,7 @@ input, textarea {
         max-width: 150px;
     }
     .menu-item {
-        max-width: 40px;
-    }
-    .menu-item:nth-last-child(-n+2) {
-        display: none;
+        max-width: none;
     }
 }
 

--- a/styles/menubar.css
+++ b/styles/menubar.css
@@ -146,14 +146,16 @@ button[role="menuitemradio"][aria-checked="true"]::before {
 
 /* Responsive adjustments */
 @media (max-width: 480px) {
-    .menu-item > button {
-        max-width: calc(var(--font-size-base) * 5.6);
-        overflow: hidden;
-        text-overflow: ellipsis;
+    /* Allow horizontal scrolling instead of truncating */
+    .global-menu-bar {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
     }
-    
-    .menu-item:nth-last-child(-n+2) {
-        display: none;
+
+    /* Let items keep their full width */
+    .menu-item,
+    .menu-item > button {
+        max-width: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- tweak responsive rules for the global menu bar
- prevent menu items from being truncated on small screens

## Testing
- `apt-get update`
- `apt-get install -y chromium-browser`


------
https://chatgpt.com/codex/tasks/task_e_685f55e95e8483218f3698fa96ee55fc