### PR TITLE
Fix submenu display on mobile

### DIFF
--- a/styles/menubar.css
+++ b/styles/menubar.css
@@ -146,3 +146,16 @@ button[role="menuitemradio"][aria-checked="true"]::before {
 
 /* Responsive adjustments */
 @media (max-width: 480px) {
+    .submenu {
+        position: fixed;
+        top: calc(var(--font-size-menu) * 1.7);
+        left: 0;
+        right: 0;
+        width: 100%;
+        min-width: 0;
+        border-radius: 0;
+    }
+    .menu-item {
+        flex: 1 0 auto;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure menu overlay styles have a responsive block for mobile devices

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686048f0bf708321adf73e9c67246044