### PR TITLE
Fix home button scroll

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -2,7 +2,7 @@
     "home": {
         "icon": "💾",
         "label": "Home",
-        "url": "/",
+        "url": "#hero",
         "aria_label": "Home"
     },
     "projects": {


### PR DESCRIPTION
## Summary
- ensure the sidebar Home icon points to the top of the page instead of reloading

## Testing
- `npm test` *(fails: package.json missing)*
- `make test` *(fails: no rule)*

------
https://chatgpt.com/codex/tasks/task_e_6860495ca7e0832188c9a1d5a6b23512