### PR TITLE
Persist dark theme setting

### DIFF
--- a/desktop/infra/under-construction/index.html
+++ b/desktop/infra/under-construction/index.html
@@ -8,6 +8,11 @@
 
 </head>
 <body>
+    <script>
+        if (localStorage.getItem('theme') === 'dark') {
+            document.body.classList.add('dark-mode');
+        }
+    </script>
     <!-- Add mobile menu toggle button -->
     <button class="menu-toggle" aria-label="Toggle navigation menu" aria-expanded="false">⋮</button>
 

--- a/desktop/projects/biohacking/index.html
+++ b/desktop/projects/biohacking/index.html
@@ -47,6 +47,11 @@
 </head>
 
 <body>
+  <script>
+    if (localStorage.getItem('theme') === 'dark') {
+      document.body.classList.add('dark-mode');
+    }
+  </script>
   <!-- Classic Mac Menu Bar -->
   <nav class="global-menu-bar" role="navigation" aria-label="Main navigation">
     <!-- Menu bar is now generated dynamically by menubar.js -->

--- a/desktop/tools/table-editor.html
+++ b/desktop/tools/table-editor.html
@@ -168,6 +168,11 @@
     </style>
 </head>
 <body>
+    <script>
+        if (localStorage.getItem('theme') === 'dark') {
+            document.body.classList.add('dark-mode');
+        }
+    </script>
     <main class="mac-window">
         <header class="window-title-bar">
             <div class="window-controls">

--- a/index.html
+++ b/index.html
@@ -63,6 +63,11 @@
 
 <body>
   <script>
+    if (localStorage.getItem('theme') === 'dark') {
+      document.body.classList.add('dark-mode');
+    }
+  </script>
+  <script>
     // Check if we're in preview mode
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get('preview') === 'true') {

--- a/scripts/globals.js
+++ b/scripts/globals.js
@@ -343,9 +343,24 @@ export function initConstructionPage() {
     typewriterEffect(dateElement);
   }
 }
-  
+
+//////////////////////////////
+// 9) THEME HANDLING        //
+//////////////////////////////
+export function initializeTheme() {
+  const saved = localStorage.getItem('theme');
+  if (saved === 'dark') {
+    document.body.classList.add('dark-mode');
+  }
+}
+
+export function toggleTheme() {
+  const isDark = document.body.classList.toggle('dark-mode');
+  localStorage.setItem('theme', isDark ? 'dark' : 'light');
+}
+
 /////////////////////////////
-// 9) MAIN INIT SEQUENCE  //
+// 10) MAIN INIT SEQUENCE //
 /////////////////////////////
 /**
  * For pages that want to load everything on DOMContentLoaded,
@@ -355,6 +370,7 @@ export function initConstructionPage() {
 
 // (Example) If you want to run specific logic automatically:
 document.addEventListener('DOMContentLoaded', () => {
+  initializeTheme();
   // Initialize auto-linkify functionality
   initAutoLinkify();
   

--- a/scripts/menubar.js
+++ b/scripts/menubar.js
@@ -1,4 +1,4 @@
-import { createDialog } from './globals.js';
+import { createDialog, toggleTheme } from './globals.js';
 
 /**
  * menubar.js
@@ -386,7 +386,7 @@ function handleToggleAction(action) {
     console.log('Handling toggle:', action);
     switch (action.target) {
         case 'theme':
-            document.body.classList.toggle('dark-mode');
+            toggleTheme();
             break;
             
         case 'layout':


### PR DESCRIPTION
## Summary
- preserve user-selected dark theme via localStorage
- toggle dark mode through new function
- apply saved theme on every page before content loads

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68604993a98c83219252351d912c2961