### PR TITLE
Fix dark-mode menu text colors

### DIFF
--- a/styles/desktop.css
+++ b/styles/desktop.css
@@ -14,6 +14,7 @@
     gap: calc(var(--font-size-base) * 1.6);
     z-index: 1;
     transition: transform 0.3s ease;
+    color: var(--primary-color);
 }
 .desktop-icon {
     display: flex;
@@ -43,7 +44,7 @@
 .icon-label {
     font-family: var(--font-primary);
     font-size: var(--font-size-sm);
-    color: var(--window-border);
+    color: inherit;
     background: var(--menu-bg);
     padding: 2px 5px;
     border-radius: 0;

--- a/styles/menubar.css
+++ b/styles/menubar.css
@@ -30,6 +30,7 @@
     z-index: 2000;
     font-family: var(--font-menu);
     font-size: var(--font-size-menu);
+    color: var(--primary-color);
     white-space: nowrap;
     overflow: visible;
 }


### PR DESCRIPTION
## Summary
- adjust dark mode colors for menu and sidebar icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860594f876c8321a1c17bbb2f0ebf17