### PR TITLE
Fix preview mobile scroll

### DIFF
--- a/styles/projects.css
+++ b/styles/projects.css
@@ -184,6 +184,7 @@ main.mac-window.project-window:hover {
     max-width: 1100px;
     max-height: 90vh;
     height: auto;
+    touch-action: pan-y; /* prevent horizontal drag on mobile */
 }
 .project-preview.active {
     display: block;
@@ -221,7 +222,9 @@ main.mac-window.project-window:hover {
     box-shadow: 4px 4px 0 rgba(0,0,0,0.2);
     position: relative;
     z-index: 2000;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior-x: contain; /* keep preview centered */
 }
 .project-preview .preview-content main.mac-window {
     margin: calc(var(--font-size-base) * 1.4);


### PR DESCRIPTION
## Summary
- prevent horizontal drag when preview window is open on mobile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6860614c6dc48321a137a79a237b08fd